### PR TITLE
feat: add optional object and string support

### DIFF
--- a/src/napi/util/napi.zig
+++ b/src/napi/util/napi.zig
@@ -45,6 +45,19 @@ pub const Napi = struct {
                             .bool => {
                                 return NapiValue.Bool.from_napi_value(env, raw, T);
                             },
+                            .optional => {
+                                switch (T.child) {
+                                    .null => {
+                                        return NapiValue.Null.New(Env.from_raw(env)).raw;
+                                    },
+                                    .undefined, .void => {
+                                        return NapiValue.Undefined.New(Env.from_raw(env)).raw;
+                                    },
+                                    else => {
+                                        return Napi.from_napi_value(env, raw, T.child);
+                                    },
+                                }
+                            },
                             else => {
                                 const hasFromRaw = @hasField(T, "from_raw");
                                 if (!hasFromRaw) {
@@ -114,6 +127,12 @@ pub const Napi = struct {
                     },
                     .bool => {
                         return NapiValue.Bool.New(Env.from_raw(env), value).raw;
+                    },
+                    .optional => {
+                        if (value == null) {
+                            return NapiValue.Undefined.New(Env.from_raw(env)).raw;
+                        }
+                        return Napi.to_napi_value(env, value);
                     },
                     else => {
                         const stringMode = comptime helper.stringLike(value_type);

--- a/src/napi/value/string.zig
+++ b/src/napi/value/string.zig
@@ -24,7 +24,7 @@ pub const String = struct {
                 const buf = allocator.alloc(u8, len + 1) catch @panic("OOM");
 
                 _ = napi.napi_get_value_string_utf8(env, raw, buf.ptr, len + 1, null);
-                return @as(T, buf);
+                return @as(T, buf[0..len]);
             },
             .Utf16 => {
                 var len: usize = 0;
@@ -34,7 +34,7 @@ pub const String = struct {
                 const buf = allocator.alloc(u16, len + 1) catch @panic("OOM");
 
                 _ = napi.napi_get_value_string_utf16(env, raw, buf.ptr, len + 1, null);
-                return @as(T, buf);
+                return @as(T, buf[0..len]);
             },
             else => {
                 @compileError("Unsupported string type");


### PR DESCRIPTION
1. Add Optional type value support: `?[]u8`
2. Allow Object set fields
3. Avoid string convert to `[]u8` length